### PR TITLE
Update quickstart.md

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,7 @@
 
 This document provides a quick set up for an up-to-date version of the Permanent Identifier Service. For a quickstart on YOURLS, see https://yourls.org/docs/guide/install. 
 For a quickstart as a contributor, see [Contributor](./contributor/) for the set up of a development environment.
-Credentials for the YOURLS web-based admin interface is set with environment variables in [docker-compose.yml](/build/docker-compose.yml).
+
 
 ## Install and Run
 
@@ -25,7 +25,7 @@ If running on localhost:
 docker compose up
 ```
 The service will be listening on http://localhost:8080.
-To access the admin page, visit http://localhost:8080admin.
+To access the admin page, visit http://localhost:8080/admin.
 
 ### Custom Host Instructions
 
@@ -37,4 +37,4 @@ docker compose up
 ```
 
 If running on a different host, the service will be listening at ``YOURLS_SITE`` in [docker-compose.yml](/build/docker-compose.yml).
-To access the admin page, visit ``YOURLS_SITE/admin``.
+To access the admin page, visit ``YOURLS_SITE/admin``. Credentials for the YOURLS web-based admin interface is set with environment variables in [docker-compose.yml](/build/docker-compose.yml).


### PR DESCRIPTION
fixed URL to include path element in Localhost instructions method. Moved directions to access default user/pass of webservice from 'About' to closer to its use in the last section of this document